### PR TITLE
Add --non-interactive flag to Travis deployment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
 
 script:
   'if [ ${TRAVIS_PULL_REQUEST} = "false" ] && [ ${TRAVIS_BRANCH} = "master" ]; then
-      npm run deploy -- --token "$FIREBASE_TOKEN";
+      npm run deploy -- --non-interactive --token "$FIREBASE_TOKEN";
   else
       npm run test;
   fi'


### PR DESCRIPTION
R: @gauntface 

See https://stackoverflow.com/questions/44736576/travis-with-firebase-deploy-typeerror-this-stream-clearline-is-not-a-function

This should fix the ongoing [Travis failures](https://travis-ci.org/GoogleChrome/workbox-microsite/builds/247562970#L326):

```sh
FIREBASE WARNING: Exception was thrown by user callback. TypeError: this.stream.clearLine is not a function
    at ProgressBar.terminate (/home/travis/build/GoogleChrome/workbox-microsite/node_modules/progress/lib/node-progress.js:177:17)
    at ProgressBar.tick (/home/travis/build/GoogleChrome/workbox-microsite/node_modules/progress/lib/node-progress.js:91:10)
    at /home/travis/build/GoogleChrome/workbox-microsite/node_modules/firebase-tools/lib/deploy/hosting/deploy.js:65:17
    at /home/travis/build/GoogleChrome/workbox-microsite/node_modules/firebase/lib/firebase-node.js:201:710
    at ec (/home/travis/build/GoogleChrome/workbox-microsite/node_modules/firebase/lib/firebase-node.js:52:165)
    at ac (/home/travis/build/GoogleChrome/workbox-microsite/node_modules/firebase/lib/firebase-node.js:31:216)
    at bc (/home/travis/build/GoogleChrome/workbox-microsite/node_modules/firebase/lib/firebase-node.js:30:1259)
    at Ji.h.Ib (/home/travis/build/GoogleChrome/workbox-microsite/node_modules/firebase/lib/firebase-node.js:220:287)
    at Rh.h.Jd (/home/travis/build/GoogleChrome/workbox-microsite/node_modules/firebase/lib/firebase-node.js:186:283)
    at Fh.Jd (/home/travis/build/GoogleChrome/workbox-microsite/node_modules/firebase/lib/firebase-node.js:176:364) 
```