### PR TITLE
Replace staticFileGlobs by globPatterns in webpack config

### DIFF
--- a/src/get-started/webpack.md
+++ b/src/get-started/webpack.md
@@ -32,7 +32,7 @@ update the service worker with the latest file changes.
       plugins: [ /* Call the plugin. */
         new workboxPlugin({
           globDirectory: DIST_DIR,
-          staticFileGlobs: ['**/*.{html,js,css}'],
+          globPatterns: ['**/*.{html,js,css}'],
           swDest: path.join(DIST_DIR, 'sw.js'),
         }),
       ]


### PR DESCRIPTION
In the "Get Started > webpack" page (https://workboxjs.org/get-started/webpack.html) there is an error in the config:
```diff
- staticFileGlobs: ['**/*.{html,js,css}'],
+ globPatterns: ['**/*.{html,js,css}'],
```